### PR TITLE
Ticket 2050 fix

### DIFF
--- a/physics/GFS_rrtmgp_gas_optics.meta
+++ b/physics/GFS_rrtmgp_gas_optics.meta
@@ -2,16 +2,16 @@
   name = GFS_rrtmgp_gas_optics_init
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type

--- a/physics/GFS_rrtmgp_lw_post.meta
+++ b/physics/GFS_rrtmgp_lw_post.meta
@@ -2,32 +2,32 @@
   name = GFS_rrtmgp_lw_post_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Grid]
-  standard_name = GFS_grid_type
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
+  standard_name = GFS_grid_type_instance
+  long_name = instance of derived type GFS_grid_type
   units = DDT
   dimensions = ()
   type = GFS_grid_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type
   intent = inout
   optional = F
 [Coupling]
-  standard_name = GFS_coupling_type
-  long_name = Fortran DDT containing FV3-GFS fields to/from coupling with other components
+  standard_name = GFS_coupling_type_instance
+  long_name = instance of derived type GFS_coupling_type
   units = DDT
   dimensions = ()
   type = GFS_coupling_type

--- a/physics/GFS_rrtmgp_post.meta
+++ b/physics/GFS_rrtmgp_post.meta
@@ -7,48 +7,48 @@
   name = GFS_rrtmgp_post_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Grid]
-  standard_name = GFS_grid_type
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
+  standard_name = GFS_grid_type_instance
+  long_name = instance of derived type GFS_grid_type
   units = DDT
   dimensions = ()
   type = GFS_grid_type
   intent = in
   optional = F
 [Diag]
-  standard_name = GFS_diag_type
-  long_name = Fortran DDT containing FV3-GFS diagnotics data
+  standard_name = GFS_diag_type_instance
+  long_name = instance of derived type GFS_diag_type
   units = DDT
   dimensions = ()
   type = GFS_diag_type
   intent = inout
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type
   intent = inout
   optional = F
 [Statein]
-  standard_name = GFS_statein_type
-  long_name = Fortran DDT containing FV3-GFS prognostic state data in from dycore
+  standard_name = GFS_statein_type_instance
+  long_name = instance of derived type GFS_statein_type
   units = DDT
   dimensions = ()
   type = GFS_statein_type
   intent = in
   optional = F
 [Coupling]
-  standard_name = GFS_coupling_type
-  long_name = Fortran DDT containing FV3-GFS fields to/from coupling with other components
+  standard_name = GFS_coupling_type_instance
+  long_name = instance of derived type GFS_coupling_type
   units = DDT
   dimensions = ()
   type = GFS_coupling_type

--- a/physics/GFS_rrtmgp_pre.meta
+++ b/physics/GFS_rrtmgp_pre.meta
@@ -2,56 +2,56 @@
   name = GFS_rrtmgp_pre_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Grid]
-  standard_name = GFS_grid_type
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
+  standard_name = GFS_grid_type_instance
+  long_name = instance of derived type GFS_grid_type
   units = DDT
   dimensions = ()
   type = GFS_grid_type
   intent = in
   optional = F
 [Sfcprop]
-  standard_name = GFS_sfcprop_type
-  long_name = Fortran DDT containing FV3-GFS surface fields
+  standard_name = GFS_sfcprop_type_instance
+  long_name = instance of derived type GFS_sfcprop_type
   units = DDT
   dimensions = ()
   type = GFS_sfcprop_type
   intent = in
   optional = F
 [Statein]
-  standard_name = GFS_statein_type
-  long_name = Fortran DDT containing FV3-GFS prognostic state data in from dycore
+  standard_name = GFS_statein_type_instance
+  long_name = instance of derived type GFS_statein_type
   units = DDT
   dimensions = ()
   type = GFS_statein_type
   intent = in
   optional = F
 [Tbd]
-  standard_name = GFS_tbd_type
-  long_name = Fortran DDT containing FV3-GFS data not yet assigned to a defined container
+  standard_name = GFS_tbd_type_instance
+  long_name = instance of derived type GFS_tbd_type
   units = DDT
   dimensions = ()
   type = GFS_tbd_type
   intent = in
   optional = F
 [Coupling]
-  standard_name = GFS_coupling_type
-  long_name = Fortran DDT containing FV3-GFS fields needed for coupling
+  standard_name = GFS_coupling_type_instance
+  long_name = instance of derived type GFS_coupling_type
   units = DDT
   dimensions = ()
   type = GFS_coupling_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type

--- a/physics/GFS_rrtmgp_sw_post.meta
+++ b/physics/GFS_rrtmgp_sw_post.meta
@@ -2,40 +2,40 @@
   name = GFS_rrtmgp_sw_post_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Grid]
-  standard_name = GFS_grid_type
-  long_name = Fortran DDT containing FV3-GFS grid and interpolation related data
+  standard_name = GFS_grid_type_instance
+  long_name = instance of derived type GFS_grid_type
   units = DDT
   dimensions = ()
   type = GFS_grid_type
   intent = in
   optional = F
 [Diag]
-  standard_name = GFS_diag_type
-  long_name = Fortran DDT containing FV3-GFS diagnotics data
+  standard_name = GFS_diag_type_instance
+  long_name = instance of derived type GFS_diag_type
   units = DDT
   dimensions = ()
   type = GFS_diag_type
   intent = inout
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type
   intent = inout
   optional = F
 [Coupling]
-  standard_name = GFS_coupling_type
-  long_name = Fortran DDT containing FV3-GFS fields to/from coupling with other components
+  standard_name = GFS_coupling_type_instance
+  long_name = instance of derived type GFS_coupling_type
   units = DDT
   dimensions = ()
   type = GFS_coupling_type

--- a/physics/rrtmgp_lw_cloud_optics.meta
+++ b/physics/rrtmgp_lw_cloud_optics.meta
@@ -2,8 +2,8 @@
   name = rrtmgp_lw_cloud_optics_init
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
@@ -64,8 +64,8 @@
   name = rrtmgp_lw_cloud_optics_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type

--- a/physics/rrtmgp_lw_clrallsky_driver.meta
+++ b/physics/rrtmgp_lw_clrallsky_driver.meta
@@ -2,16 +2,16 @@
   name = rrtmgp_lw_clrallsky_driver_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type

--- a/physics/rrtmgp_lw_gas_optics.meta
+++ b/physics/rrtmgp_lw_gas_optics.meta
@@ -2,16 +2,16 @@
   name = rrtmgp_lw_gas_optics_init
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type
@@ -80,16 +80,16 @@
   name = rrtmgp_lw_gas_optics_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type

--- a/physics/rrtmgp_lw_rte.meta
+++ b/physics/rrtmgp_lw_rte.meta
@@ -2,24 +2,24 @@
   name = rrtmgp_lw_rte_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type
   intent = in
   optional = F
 [Statein]
-  standard_name = GFS_statein_type
-  long_name = Fortran DDT containing FV3-GFS prognostic state data in from dycore
+  standard_name = GFS_statein_type_instance
+  long_name = instance of derived type GFS_statein_type
   units = DDT
   dimensions = ()
   type = GFS_statein_type

--- a/physics/rrtmgp_sw_cloud_optics.meta
+++ b/physics/rrtmgp_sw_cloud_optics.meta
@@ -2,8 +2,8 @@
   name = rrtmgp_sw_cloud_optics_init
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
@@ -64,8 +64,8 @@
   name = rrtmgp_sw_cloud_optics_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type

--- a/physics/rrtmgp_sw_clrallsky_driver.meta
+++ b/physics/rrtmgp_sw_clrallsky_driver.meta
@@ -2,16 +2,16 @@
   name = rrtmgp_sw_clrallsky_driver_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type

--- a/physics/rrtmgp_sw_gas_optics.meta
+++ b/physics/rrtmgp_sw_gas_optics.meta
@@ -2,16 +2,16 @@
   name = rrtmgp_sw_gas_optics_init
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type
@@ -80,16 +80,16 @@
   name = rrtmgp_sw_gas_optics_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type

--- a/physics/rrtmgp_sw_rte.meta
+++ b/physics/rrtmgp_sw_rte.meta
@@ -2,24 +2,24 @@
   name = rrtmgp_sw_rte_run
   type = scheme
 [Model]
-  standard_name = GFS_control_type
-  long_name = Fortran DDT containing FV3-GFS model control parameters
+  standard_name = GFS_control_type_instance
+  long_name = instance of derived type GFS_control_type
   units = DDT
   dimensions = ()
   type = GFS_control_type
   intent = in
   optional = F
 [Radtend]
-  standard_name = GFS_radtend_type
-  long_name = Fortran DDT containing FV3-GFS radiation tendencies
+  standard_name = GFS_radtend_type_instance
+  long_name = instance of derived type GFS_radtend_type
   units = DDT
   dimensions = ()
   type = GFS_radtend_type
   intent = in
   optional = F
 [Statein]
-  standard_name = GFS_statein_type
-  long_name = Fortran DDT containing FV3-GFS prognostic state data in from dycore
+  standard_name = GFS_statein_type_instance
+  long_name = instance of derived type GFS_statein_type
   units = DDT
   dimensions = ()
   type = GFS_statein_type


### PR DESCRIPTION
 - change RRTMGP scheme metadata to use instances of DDTs rather than the type definition

compiles on my Mac with LLVM/gfortran